### PR TITLE
Add a separate task for running scapegoat analysis. Fixes #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ If the plugin is working properly then you should see output like this in your b
 [info] [scapegoat]: Written XML report [/home/sam/development/workspace/elastic4s/target/scala-2.11/scapegoat-report/scapegoat.xml]
 ```
 
+#### Turning off scapegoat for incremental compiles
+
+By default the plugin will run the analysis on every compile, whether that
+compile would compile all the sources or not. This can be convenient if you want
+to keep on top of the errors and fix them as you make them. However, the
+analysis can increase the compile time. If you would prefer faster compile
+times, you can disable scapegoat for incremental compiles triggered by the
+`compile` task by setting `scapegoatAlways` to `false`. You can always run a
+full analysis by running the `scapegoat` task.
+
 #### Inspections list
 
 The full list of inspections can be seen at the [scapegoat](https://github.com/sksamuel/scapegoat) main page.

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #Project properties
 #Mon Feb 28 11:55:49 PST 2011
-sbt.version=0.13.5
+sbt.version=0.13.8


### PR DESCRIPTION
Two things to know about this patch. First, and most importantly, it forces the
plugin to depend on sbt 0.13.8 due to the use of `Def.sequential` to control
task ordering in the `scapegoat` task. Secondly, and the reason that we need to
use Def.sequential, is that it's a little ugly since it depends on side effects
on the ScapegoatPlugin object to enable and disable the analysis. I tried
several different ways to do this that wouldn't have needed side effects, but
controlling the compile settings the way we need to is hard to do, since the
compile task generator depends on (at least one) experimental, private setting
key, and just copying the compile task doesn't make it pick up a
`scalacOptions` task in a different scope.