### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The full list of inspections can be seen at the [scapegoat](https://github.com/s
 
 sbt-scapegoat generates three sets of output. HTML and XML reports inside `target/scala-2.x/scapegoat-report` and also to the console during the build. The latter is useful so you don't have to open up files to see inspection warnings. However you can disable the console output if needed by setting the following key:
 
+`import com.sksamuel.scapegoat.sbt.ScapegoatSbtPlugin.autoImport._`
 `scapegoatConsoleOutput := false`
 
 #### Disabling inspections


### PR DESCRIPTION
I had to hunt around in the source code for 30 minutes to find the import statement necessary to get the scapegoat settings in scope.  I added it to the documentation.  If this isn't a good place for it, feel free to nuke it, but it would be really helpful to have it in the docs.  Thanks.  This library rules.