### PR TITLE
97 custom inspections

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,6 @@
+Building sbt-scapegoat
+======================
+
+To run all tests, run
+
+    sbt test scripted

--- a/README.md
+++ b/README.md
@@ -115,15 +115,15 @@ The `scapegoatCustomInspectionsClasspath` SBT SettingKey needs to list the class
 
     scapegoatCustomInspectionsClasspath := List(new File("lib/my-inpections-1.0.jar"))
 
-If you would like to have the inspection classes in the same project, you can add them to the SBT `project/` build. Put your inspection classes under `project/src/main/scala` and use the following for the `scapegoatCustomInspectionsClasspath `:
+If you would like to have the inspection classes in the same project, you can add them to the SBT `project/` build. Put your inspection classes under `project` (e.g. `project/src/main/scala/my/inspections/MyInspection.scala`) and use the following for the `scapegoatCustomInspectionsClasspath`:
 
 
       scapegoatCustomInspectionsClasspath := List({
-        // Get the CP dir for the inspections.
+        // Get the classpath dir of the SBT build to allow loading the inspections.
         // There might be a better way to get this from SBT, but I can't find it.
         // You can always hardcode "./project/target/scala-2.10/sbt-0.13/classes/" if you don't
         // like this.
-        classOf[LoggingArgumentsMismatch].getClassLoader match {
+        classOf[my.inspections.MyInspection].getClassLoader match {
           case urlLoader: java.net.URLClassLoader => urlLoader.getURLs.toList match {
             case List(u) if u.getProtocol == "file" =>
               new File(u.toURI)

--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ project-specific rule.
 
 How to write and test the inspection class is described in [the scalac-scapegoat-plugin CustomInspections readme](https://github.com/sksamuel/scalac-scapegoat-plugin/blob/master/CustomInspections.md)
 
-Your inspections need to be compiled before the code in the rest of your project is compiled (like macros). You can achieve this with a project set up like the following:
+Your inspections need to be compiled before the code in the rest of your project is compiled (like macros).
+If your inspections are in the same project as the code, you can achieve this
+with a project set up like the following:
 
     object MyBuild extends Build {
     
@@ -119,8 +121,8 @@ Your inspections need to be compiled before the code in the rest of your project
           scapegoatCustomInspections := List(
             "my.inspections.InspectionOne",
             "my.inspections.InspectionTwo"),
-          scapegoatCustomInspectionsClasspath := List(
-            (classDirectory in inspections in Scapegoat).value))
+          scapegoatCustomInspectionsClasspath +=
+            (classDirectory in inspections in Scapegoat).value)
         .dependsOn(inspections)
     
       lazy val inspections = Project("inspections", file("inspections"))
@@ -134,7 +136,8 @@ Your inspections need to be compiled before the code in the rest of your project
 (There is a full worked example of a project with custom inspections in this repository
 at [src/sbt-test/scapegoat/custom-inspection-in-subproject](src/sbt-test/scapegoat/custom-inspection-in-subproject).)
 
-If your custom inspections come from a separate JAR, then your build will need to look more like this:
+If your custom inspections come from a separate JAR, then your build will need
+to look like this:
 
     object MyBuild extends Build {
     
@@ -147,11 +150,12 @@ If your custom inspections come from a separate JAR, then your build will need t
           scapegoatCustomInspections := List(
             "my.inspections.InspectionOne",
             "my.inspections.InspectionTwo"),
-          scapegoatCustomInspectionsClasspath := List(
-            "lib/my-inspections-1.0.0.jar")
+          scapegoatCustomInspectionsDependencies +=
+            "my.inspections" %% "inspections" % "1.0.0")
     }
 
-The `scapegoatCustomInspectionsClasspath` SBT SettingKey needs to list the classpath entries at which your inspection classes can be loaded. (There is not currently automatic support for using an Ivy-provided JAR dependency here. You may be able to do this by accessing the "update" SBT TaskKey. There is some code along these lines in [sbt-scapegoat](https://github.com/sksamuel/sbt-scapegoat/blob/ae4231d1341eeece323e111c757d57d904e66f7b/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala#L41) which you can use for inspiration. However, this probably won't work as SBT Settings may not depend on SBT Tasks.)
+(There is a full worked example of a project with custom inspections from a JAR in this repository
+at [src/sbt-test/scapegoat/custom-inspection-in-external-project](src/sbt-test/scapegoat/custom-inspection-in-external-project).)
 
 (Note that it is not currently possible to put the inspection classes inside the SBT `project/` build
 directory, as SBT uses Scala 2.10 and `scapegoat` works only with 2.11. You must create a separate project or JAR to hold the inspections.)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sbt-scapegoat is an [auto plugin](https://typesafe.com/blog/preview-of-upcoming-
 Add the plugin to your build with the following in project/plugins.sbt:
 
 ```scala
-addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.0.0")
+addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.1.0")
 ```
 
 That's it! You can now generate the scapegoat reports using the `scapegoat`

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Your inspections need to be compiled before the code in the rest of your project
           scalaVersion := scalaV)
     }
 
+(There is a full worked example of a project with custom inspections in this repository
+at [src/sbt-test/scapegoat/custom-inspection-in-subproject](src/sbt-test/scapegoat/custom-inspection-in-subproject).)
 
 If your custom inspections come from a separate JAR, then your build will need to look more like this:
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "sbt-scapegoat"
 
 organization := "com.sksamuel.scapegoat"
 
-version := "1.0.0"
+version := "1.1.0"
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8")
 

--- a/build.sbt
+++ b/build.sbt
@@ -22,3 +22,10 @@ publishMavenStyle := false
 publishArtifact in Test := false
 
 parallelExecution in Test := false
+
+ScriptedPlugin.scriptedSettings
+
+scriptedLaunchOpts ++= Seq(
+  "-Xmx1024M", "-XX:MaxPermSize=256M",
+  "-Dplugin.version=" + version.value
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,7 @@
 resolvers += Classpaths.sbtPluginReleases
 
+libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")

--- a/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
@@ -66,7 +66,9 @@ object ScapegoatSbtPlugin extends AutoPlugin {
                 Some("-P:scapegoat:verbose:" + scapegoatVerbose.value),
                 Some("-P:scapegoat:consoleOutput:" + scapegoatConsoleOutput.value),
                 Some("-P:scapegoat:dataDir:" + path),
+                // FIXME: the corresponding option in scalac-scapegoat has a different name!
                 if (disabled.isEmpty) None else Some("-P:scapegoat:disabledInspections:" + disabled.mkString(":")),
+                // FIXME: no corresponding 'enabledInspections' option in scalac-scapegoat!
                 if (enabled.isEmpty) None else Some("-P:scapegoat:enabledInspections:" + enabled.mkString(":")),
                 if (ignoredFilePatterns.isEmpty) None else Some("-P:scapegoat:ignoredFiles:" + ignoredFilePatterns.mkString(":")),
                 if (reports.isEmpty) None else Some("-P:scapegoat:reports:" + reports.mkString(":"))

--- a/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
@@ -16,11 +16,26 @@ object ScapegoatSbtPlugin extends AutoPlugin {
     lazy val scapegoatVersion = settingKey[String]("The version of the scala plugin to use")
     lazy val scapegoatDisabledInspections = settingKey[Seq[String]]("Inspections that are disabled globally, by simple name")
     lazy val scapegoatEnabledInspections = settingKey[Seq[String]]("Inspections that are explicitly enabled, by simple name")
-    lazy val scapegoatCustomInspections = settingKey[Seq[String]]("Externally defined inspections to load, by full class name. Each class should implement com.sksamuel.scapegoat.Inspection.")
-    lazy val scapegoatCustomInspectionsDependencies = settingKey[Seq[sbt.ModuleID]]("Ivy dependencies containing custom inspections. " +
-      "These will be added to scapegoatCustomInspectionsClasspath.")
-    lazy val scapegoatCustomInspectionsClasspath = taskKey[Seq[File]]("Classpaths from which to load custom inspections. " +
-      "If you also use scapegoatCustomInspectionsDependencies, be sure to use '+=' not ':=' to set this.")
+    lazy val scapegoatCustomInspectionsClasspath = taskKey[Seq[File]](
+      "Classpaths from which to load custom inspections. " +
+        "The classpaths will be scanned for classes which implement " +
+        "`com.sksamuel.scapegoat.Inspection` using the ServiceLoader API " +
+        "(i.e. the full classname must be listed in a resource of name " +
+        "`META-INF/services/com.sksamuel.scapegoat.Inspection`), " +
+        "and any found will be added to the scapegoat checks. " +
+        "If you also set scapegoatCustomInspectionsDependencies, be sure to " +
+        "use '+=' not ':=' to set this unless you want to disable the " +
+        "automatic addition of those dependencies to this classpath.")
+    lazy val scapegoatCustomInspectionsDependencies = settingKey[Seq[sbt.ModuleID]](
+      "Ivy dependencies containing custom inspections. " +
+        "The dependencies will be scanned for classes which implement " +
+        "`com.sksamuel.scapegoat.Inspection` using the ServiceLoader API " +
+        "(i.e. the full classname must be listed in a resource of name " +
+        "`META-INF/services/com.sksamuel.scapegoat.Inspection`), " +
+        "and any found will be added to the scapegoat checks. " +
+        "(If the inspection libraries have any transitive dependencies " +
+        "which the compiler will need, you currently have to manually add those " +
+        "to scapegoatCustomInspectionsClasspath.)")
     lazy val scapegoatIgnoredFiles = settingKey[Seq[String]]("File patterns to ignore")
     lazy val scapegoatMaxErrors = settingKey[Int]("Maximum number of errors before the build will fail")
     lazy val scapegoatMaxWarnings = settingKey[Int]("Maximum number of warnings before the build will fail")
@@ -39,6 +54,8 @@ object ScapegoatSbtPlugin extends AutoPlugin {
       Defaults.compileSettings ++
       Seq(
         sources := (sources in Compile).value,
+        resources := (resources in Compile).value,
+        resourceDirectories := (resourceDirectories in Compile).value,
         scalacOptions := {
           // Ensure we have the scapegoat dependency on the classpath and
           // add it as a scalac plugin:
@@ -65,10 +82,6 @@ object ScapegoatSbtPlugin extends AutoPlugin {
               if (enabled.nonEmpty && verbose)
                 streams.value.log.info("[scapegoat] enabled inspections: " + enabled.mkString(","))
 
-              val custom = scapegoatCustomInspections.value.filterNot(_.trim.isEmpty)
-              if (custom.nonEmpty && verbose)
-                streams.value.log.info("[scapegoat] custom inspections: " + custom.mkString(","))
-
               val customCp = scapegoatCustomInspectionsClasspath.value.map(_.toURI.toString)
               if (customCp.nonEmpty && verbose)
                 streams.value.log.info("[scapegoat] custom inspections classpath: " + customCp.mkString(";"))
@@ -86,7 +99,6 @@ object ScapegoatSbtPlugin extends AutoPlugin {
                 if (disabled.isEmpty) None else Some("-P:scapegoat:disabledInspections:" + disabled.mkString(":")),
                 // FIXME: no corresponding 'enabledInspections' option in scalac-scapegoat!
                 if (enabled.isEmpty) None else Some("-P:scapegoat:enabledInspections:" + enabled.mkString(":")),
-                if (custom.isEmpty) None else Some("-P:scapegoat:customInspections:" + custom.mkString(":")),
                 if (customCp.isEmpty) None else Some("-P:scapegoat:customInspectionsClasspath:" + customCp.mkString(";")),
                 if (ignoredFilePatterns.isEmpty) None else Some("-P:scapegoat:ignoredFiles:" + ignoredFilePatterns.mkString(":")),
                 if (reports.isEmpty) None else Some("-P:scapegoat:reports:" + reports.mkString(":"))
@@ -97,7 +109,8 @@ object ScapegoatSbtPlugin extends AutoPlugin {
     } ++ Seq(
       scapegoat := {
         clean.value
-        (compile in Scapegoat).value
+        // (products is compile + copy resources)
+        (products in Scapegoat).value
       },
       scapegoatVersion := "1.1.0",
       scapegoatConsoleOutput := true,
@@ -107,12 +120,16 @@ object ScapegoatSbtPlugin extends AutoPlugin {
       scapegoatMaxErrors := -1,
       scapegoatDisabledInspections := Nil,
       scapegoatEnabledInspections := Nil,
-      scapegoatCustomInspections := Nil,
       scapegoatCustomInspectionsDependencies := Nil,
+      /**
+       * The custom inspections classpath includes, by default, all the
+       * JARs from [[scapegoatCustomInspectionsDependencies]].
+       *
+       * @see [[scapegoatCustomInspections]] which will scan each of these
+       *      classpath entries for implementations of Inspection.
+       */
       scapegoatCustomInspectionsClasspath := {
 
-        // The default custom inspections classpath is the resolved artifact Files
-        // for all modules which were listed as "scapegoatCustomInspectionsDependencies"
         val resolvedDeps = (update in Scapegoat).value
         val crossVersioner = CrossVersion.apply(
           (scalaVersion in Scapegoat).value, (scalaBinaryVersion in Scapegoat).value)
@@ -123,9 +140,9 @@ object ScapegoatSbtPlugin extends AutoPlugin {
           val expectedModId = crossVersioner(modId)
           resolvedDeps
             .select(module = (m: ModuleID) =>
-              // Compare the "toString"s of the ModuleID, otherwise config differences
-              // like the CrossVersion settings will fail the comparison:
-              m.toString() == expectedModId.toString())
+            // Compare the "toString"s of the ModuleID, otherwise config differences
+            // like the CrossVersion settings will fail the comparison:
+            m.toString() == expectedModId.toString())
             .ensuring(
               _.nonEmpty,
               s"No resolved Ivy artifacts found for $expectedModId")

--- a/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
@@ -93,7 +93,7 @@ object ScapegoatSbtPlugin extends AutoPlugin {
         clean.value
         (compile in Scapegoat).value
       },
-      scapegoatVersion := "1.0.0",
+      scapegoatVersion := "1.1.0",
       scapegoatConsoleOutput := true,
       scapegoatVerbose := true,
       scapegoatMaxInfos := -1,

--- a/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
@@ -63,16 +63,7 @@ object ScapegoatSbtPlugin extends AutoPlugin {
               if (custom.nonEmpty && verbose)
                 streams.value.log.info("[scapegoat] custom inspections: " + custom.mkString(","))
 
-              val customCp = scapegoatCustomInspectionsClasspath.value
-                .map { file =>
-                  var uri = file.toURI.toString
-                  // Catch a tricky error: URLClassLoader will only treat dirs as such if they have a
-                  // trailing /
-                  if (file.isDirectory && !uri.endsWith("/")) {
-                    uri += "/"
-                  }
-                  uri
-                }
+              val customCp = scapegoatCustomInspectionsClasspath.value.map(_.toURI.toString)
               if (customCp.nonEmpty && verbose)
                 streams.value.log.info("[scapegoat] custom inspections classpath: " + customCp.mkString(";"))
 

--- a/src/sbt-test/scapegoat/basic-operation/build.sbt
+++ b/src/sbt-test/scapegoat/basic-operation/build.sbt
@@ -1,0 +1,1 @@
+scalaVersion := "2.11.6"

--- a/src/sbt-test/scapegoat/basic-operation/project/plugins.sbt
+++ b/src/sbt-test/scapegoat/basic-operation/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % pluginVersion)
+}

--- a/src/sbt-test/scapegoat/basic-operation/src/main/scala/my/app/Example.scala
+++ b/src/sbt-test/scapegoat/basic-operation/src/main/scala/my/app/Example.scala
@@ -1,0 +1,10 @@
+package my.app
+
+object Example {
+
+  def exampleCodeUsingArrayToString(a: Array[Int]): Unit = {
+    // This is just some example code which demonstrates that the Inspection
+    // "ArraysToString" is working.
+    println("The array contained: " + a.toString)
+  }
+}

--- a/src/sbt-test/scapegoat/basic-operation/test
+++ b/src/sbt-test/scapegoat/basic-operation/test
@@ -1,0 +1,7 @@
+# This example project checks that `scapegoat` can find some errors.
+# The project can be built and tested:
+> test
+# Scapegoat should run OK:
+> scapegoat
+# The project has scapegoat warnings:
+$ exec grep ArraysToString target/scala-2.11/scapegoat-report/scapegoat-scalastyle.xml

--- a/src/sbt-test/scapegoat/custom-inspection-in-external-project/project/Build.scala
+++ b/src/sbt-test/scapegoat/custom-inspection-in-external-project/project/Build.scala
@@ -1,0 +1,25 @@
+import com.sksamuel.scapegoat.sbt.ScapegoatSbtPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+
+object CustomInspectionInExternalProject extends Build {
+
+  val scalaV = "2.11.6"
+
+  lazy val project = Project("CustomInspectionInExternalProject", file("."))
+    .settings(
+      scalaVersion := scalaV,
+
+      // FIXME: Having to list the classes here is error-prone.
+      // There are two main cases:
+      //   1. When the inspection lib is in the same build, then SBT might be able to enumerate the
+      //      classes here if we depend on the inspections/compile Task.
+      //      However, SBT 'settings' are not allowed to depend on SBT 'tasks', so that might not work.
+      //   2. When the inspection lib is externally sourced, we might be able to grab it from the
+      //      JAR metadata somehow? Do we need to fix an API for scapegoat plugins?
+      scapegoatCustomInspections := List(
+        "my.inspections.DisallowJavaDateConstruction"),
+
+      scapegoatCustomInspectionsDependencies +=
+        "com.sksamuel.scapegoat.examples" %% "inspections" % "1.0.0")
+}

--- a/src/sbt-test/scapegoat/custom-inspection-in-external-project/project/Build.scala
+++ b/src/sbt-test/scapegoat/custom-inspection-in-external-project/project/Build.scala
@@ -10,16 +10,6 @@ object CustomInspectionInExternalProject extends Build {
     .settings(
       scalaVersion := scalaV,
 
-      // FIXME: Having to list the classes here is error-prone.
-      // There are two main cases:
-      //   1. When the inspection lib is in the same build, then SBT might be able to enumerate the
-      //      classes here if we depend on the inspections/compile Task.
-      //      However, SBT 'settings' are not allowed to depend on SBT 'tasks', so that might not work.
-      //   2. When the inspection lib is externally sourced, we might be able to grab it from the
-      //      JAR metadata somehow? Do we need to fix an API for scapegoat plugins?
-      scapegoatCustomInspections := List(
-        "my.inspections.DisallowJavaDateConstruction"),
-
       scapegoatCustomInspectionsDependencies +=
         "com.sksamuel.scapegoat.examples" %% "inspections" % "1.0.0")
 }

--- a/src/sbt-test/scapegoat/custom-inspection-in-external-project/project/plugins.sbt
+++ b/src/sbt-test/scapegoat/custom-inspection-in-external-project/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % pluginVersion)
+}

--- a/src/sbt-test/scapegoat/custom-inspection-in-external-project/src/main/scala/my/app/Example.scala
+++ b/src/sbt-test/scapegoat/custom-inspection-in-external-project/src/main/scala/my/app/Example.scala
@@ -1,0 +1,12 @@
+package my.app
+
+import java.util.Date
+
+object Example {
+
+  def exampleCodeUsingNewDate(): Unit = {
+    // This is just some example code which demonstrates that the Inspection
+    // is working".
+    println(new Date())
+  }
+}

--- a/src/sbt-test/scapegoat/custom-inspection-in-external-project/test
+++ b/src/sbt-test/scapegoat/custom-inspection-in-external-project/test
@@ -1,0 +1,10 @@
+# This example project depends on the sibling example
+# 'custom-inspection-in-subproject'.
+# The inspections from that demo have been "publishLocal"ed by the build.sbt
+# in the top-level project.
+# The project can be built and tested:
+> test
+# Scapegoat should run OK:
+> scapegoat
+# The project has scapegoat warnings:
+$ exec grep DisallowJavaDateConstruction target/scala-2.11/scapegoat-report/scapegoat-scalastyle.xml

--- a/src/sbt-test/scapegoat/custom-inspection-in-subproject/inspections/src/main/resources/META-INF/services/com.sksamuel.scapegoat.Inspection
+++ b/src/sbt-test/scapegoat/custom-inspection-in-subproject/inspections/src/main/resources/META-INF/services/com.sksamuel.scapegoat.Inspection
@@ -1,0 +1,1 @@
+my.inspections.DisallowJavaDateConstruction

--- a/src/sbt-test/scapegoat/custom-inspection-in-subproject/inspections/src/main/scala/my/inspections/DisallowJavaDateConstruction.scala
+++ b/src/sbt-test/scapegoat/custom-inspection-in-subproject/inspections/src/main/scala/my/inspections/DisallowJavaDateConstruction.scala
@@ -1,0 +1,33 @@
+package my.inspections
+
+import com.sksamuel.scapegoat._
+
+/**
+ * A compile-time [[Inspection]] which detects usage of "new java.util.Date()"
+ * as an example.
+ */
+class DisallowJavaDateConstruction extends Inspection {
+
+  def inspector(context: InspectionContext): Inspector = new Inspector(context) {
+
+    import context.global._
+
+    override def postTyperTraverser = Some(new context.Traverser {
+
+      override def inspect(tree: Tree): Unit = tree match {
+
+        case New(clazz) if clazz.toString() == "java.util.Date" =>
+          context.warn(
+            "Use of new java.util.Date() is disallowed",
+            tree.pos,
+            Levels.Error,
+            "In this project, you may not directly construct a new Date(). Instead, please " +
+              "use our hypothetical super test framework which lets you inject a mock time. " +
+              "(Don't get too hung up on this inpsection; it's just an example!)",
+            DisallowJavaDateConstruction.this)
+
+        case _ => continue(tree)
+      }
+    })
+  }
+}

--- a/src/sbt-test/scapegoat/custom-inspection-in-subproject/inspections/src/main/scala/my/inspections/DisallowJavaDateConstruction.scala
+++ b/src/sbt-test/scapegoat/custom-inspection-in-subproject/inspections/src/main/scala/my/inspections/DisallowJavaDateConstruction.scala
@@ -20,7 +20,7 @@ class DisallowJavaDateConstruction extends Inspection {
           context.warn(
             "Use of new java.util.Date() is disallowed",
             tree.pos,
-            Levels.Error,
+            Levels.Warning,
             "In this project, you may not directly construct a new Date(). Instead, please " +
               "use our hypothetical super test framework which lets you inject a mock time. " +
               "(Don't get too hung up on this inpsection; it's just an example!)",

--- a/src/sbt-test/scapegoat/custom-inspection-in-subproject/inspections/src/test/scala/my/inspections/DisallowJavaDateConstructionSpec.scala
+++ b/src/sbt-test/scapegoat/custom-inspection-in-subproject/inspections/src/test/scala/my/inspections/DisallowJavaDateConstructionSpec.scala
@@ -1,0 +1,43 @@
+package my.inspections
+
+import com.sksamuel.scapegoat.test.ScapegoatTestPluginRunner
+import org.scalatest.{OneInstancePerTest, Matchers, FreeSpec}
+
+class DisallowJavaDateConstructionSpec
+  extends FreeSpec
+  with Matchers
+  with ScapegoatTestPluginRunner
+  with OneInstancePerTest {
+
+  override val inspections = Seq(new DisallowJavaDateConstruction)
+
+  "DisallowJavaDateConstruction" - {
+    "should report warning when java.util.Date constructed" in {
+
+      val code =
+        """import java.util.Date
+          |
+          |class Test {
+          |  println(new Date())
+          |}
+        """.stripMargin
+
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 1
+    }
+
+    "should not report warning when other Date constructed" in {
+
+      val code =
+        """class Date {}
+          |
+          |class Test {
+          |  println(new Date())
+          |}
+        """.stripMargin
+
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 0
+    }
+  }
+}

--- a/src/sbt-test/scapegoat/custom-inspection-in-subproject/project/Build.scala
+++ b/src/sbt-test/scapegoat/custom-inspection-in-subproject/project/Build.scala
@@ -14,16 +14,6 @@ object CustomInspectionInSubproject extends Build {
       scalaVersion := scalaV,
       publishLocal := {},
 
-      // FIXME: Having to list the classes here is error-prone.
-      // There are two main cases:
-      //   1. When the inspection lib is in the same build, then SBT might be able to enumerate the
-      //      classes here if we depend on the inspections/compile Task.
-      //      However, SBT 'settings' are not allowed to depend on SBT 'tasks', so that might not work.
-      //   2. When the inspection lib is externally sourced, we might be able to grab it from the
-      //      JAR metadata somehow? Do we need to fix an API for scapegoat plugins?
-      scapegoatCustomInspections := List(
-        "my.inspections.DisallowJavaDateConstruction"),
-
       scapegoatCustomInspectionsClasspath +=
         (classDirectory in inspections in Scapegoat).value)
 

--- a/src/sbt-test/scapegoat/custom-inspection-in-subproject/project/Build.scala
+++ b/src/sbt-test/scapegoat/custom-inspection-in-subproject/project/Build.scala
@@ -1,0 +1,47 @@
+import com.sksamuel.scapegoat.sbt.ScapegoatSbtPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+
+object ScapegoatCustomInspectionsExample extends Build {
+
+  val scalaV = "2.11.6"
+
+  lazy val project = Project("ScapegoatCustomInspectionsExample", file("."))
+    // "aggregate" causes these child projects to be built and tested whenever
+    // the parent project is built and tested.
+    .aggregate(inspections)
+    .settings(
+      scalaVersion := scalaV,
+
+      // FIXME: Having to list the classes here is error-prone.
+      // There are two main cases:
+      //   1. When the inspection lib is in the same build, then SBT might be able to enumerate the
+      //      classes here if we depend on the inspections/compile Task.
+      //      However, SBT 'settings' are not allowed to depend on SBT 'tasks', so that might not work.
+      //   2. When the inspection lib is externally sourced, we might be able to grab it from the
+      //      JAR metadata somehow? Do we need to fix an API for scapegoat plugins?
+      scapegoatCustomInspections := List(
+        "my.inspections.DisallowJavaDateConstruction"),
+
+      scapegoatCustomInspectionsClasspath := List(
+        (classDirectory in inspections in Scapegoat).value))
+
+    // FIXME: this dependency ought to be in scope 'provided', as it is
+    // compile only, so is not needed at runtime.
+    // Unfortunately, the current definition of the SBT 'scapegoat' task
+    // includes a "clean", which means that SBT will delete the compiled
+    // inspection classes just before attempting to run the inspections.
+    // If the dependency here is "compile" then SBT knows to rebuild the
+    // inspections before running them, however it does not add that
+    // task dependency if this is marked "provided". I think that is a
+    // bug in SBT.
+    .dependsOn(inspections)
+
+  lazy val inspections = Project("inspections", file("inspections"))
+    .settings(
+      libraryDependencies ++= List(
+        "com.sksamuel.scapegoat" %% "scalac-scapegoat-plugin" % "1.1.0",
+        "org.scala-lang"         %  "scala-compiler"          % scalaV,
+        "org.scalatest"          %% "scalatest"               % "2.2.4" % "test"),
+      scalaVersion := scalaV)
+}

--- a/src/sbt-test/scapegoat/custom-inspection-in-subproject/project/Build.scala
+++ b/src/sbt-test/scapegoat/custom-inspection-in-subproject/project/Build.scala
@@ -2,16 +2,17 @@ import com.sksamuel.scapegoat.sbt.ScapegoatSbtPlugin.autoImport._
 import sbt.Keys._
 import sbt._
 
-object ScapegoatCustomInspectionsExample extends Build {
+object CustomInspectionInSubproject extends Build {
 
   val scalaV = "2.11.6"
 
-  lazy val project = Project("ScapegoatCustomInspectionsExample", file("."))
+  lazy val project = Project("CustomInspectionInSubproject", file("."))
     // "aggregate" causes these child projects to be built and tested whenever
     // the parent project is built and tested.
     .aggregate(inspections)
     .settings(
       scalaVersion := scalaV,
+      publishLocal := {},
 
       // FIXME: Having to list the classes here is error-prone.
       // There are two main cases:
@@ -23,8 +24,8 @@ object ScapegoatCustomInspectionsExample extends Build {
       scapegoatCustomInspections := List(
         "my.inspections.DisallowJavaDateConstruction"),
 
-      scapegoatCustomInspectionsClasspath := List(
-        (classDirectory in inspections in Scapegoat).value))
+      scapegoatCustomInspectionsClasspath +=
+        (classDirectory in inspections in Scapegoat).value)
 
     // FIXME: this dependency ought to be in scope 'provided', as it is
     // compile only, so is not needed at runtime.
@@ -39,6 +40,8 @@ object ScapegoatCustomInspectionsExample extends Build {
 
   lazy val inspections = Project("inspections", file("inspections"))
     .settings(
+      organization  := "com.sksamuel.scapegoat.examples",
+      version := "1.0.0",
       libraryDependencies ++= List(
         "com.sksamuel.scapegoat" %% "scalac-scapegoat-plugin" % "1.1.0",
         "org.scala-lang"         %  "scala-compiler"          % scalaV,

--- a/src/sbt-test/scapegoat/custom-inspection-in-subproject/project/plugins.sbt
+++ b/src/sbt-test/scapegoat/custom-inspection-in-subproject/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % pluginVersion)
+}

--- a/src/sbt-test/scapegoat/custom-inspection-in-subproject/src/main/scala/my/app/Example.scala
+++ b/src/sbt-test/scapegoat/custom-inspection-in-subproject/src/main/scala/my/app/Example.scala
@@ -1,0 +1,12 @@
+package my.app
+
+import java.util.Date
+
+object Example {
+
+  def exampleCodeUsingNewDate(): Unit = {
+    // This is just some example code which demonstrates that the Inspection
+    // is working".
+    println(new Date())
+  }
+}

--- a/src/sbt-test/scapegoat/custom-inspection-in-subproject/test
+++ b/src/sbt-test/scapegoat/custom-inspection-in-subproject/test
@@ -1,5 +1,7 @@
 # The project can be built and tested.
 # This includes unit tests for the custom inspections
 > test
+# Scapegoat should run OK:
+> scapegoat
 # The project has scapegoat warnings:
--> scapegoat
+$ exec grep DisallowJavaDateConstruction target/scala-2.11/scapegoat-report/scapegoat-scalastyle.xml

--- a/src/sbt-test/scapegoat/custom-inspection-in-subproject/test
+++ b/src/sbt-test/scapegoat/custom-inspection-in-subproject/test
@@ -1,0 +1,5 @@
+# The project can be built and tested.
+# This includes unit tests for the custom inspections
+> test
+# The project has scapegoat warnings:
+-> scapegoat


### PR DESCRIPTION
This implements https://github.com/sksamuel/scalac-scapegoat-plugin/issues/97

This is part of https://github.com/sksamuel/scalac-scapegoat-plugin/pull/114

(I haven't written any tests, as it's not very amenable to unit testing.)

I have only tested this with in-project inspections. I wrote the README to include instructions for inspections in JARs, but I haven't actually tested that.
