### PR TITLE
Remove the hard dependency on clean.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ task:
 [info] [scapegoat]: Written XML report [/home/sam/development/workspace/elastic4s/target/scala-2.11/scapegoat-report/scapegoat.xml]
 ```
 
-You should find the reports inside `target/scala-2.11/scapegoat-report`. By default, the reports will be regenerated for all files on every invocation of the `scapegoat` task. If you'd prefer to only have reports generated for files that have changed between invocations, you can set the `scapegoatAlways` setting to false. You can then manually force a full inspection by invoking the `scapegoatForceClean` task, or by doing a full `clean`.
+You should find the reports inside `target/scala-2.11/scapegoat-report`. By default, the reports will be regenerated for all files on every invocation of the `scapegoat` task. If you'd prefer to only have reports generated for files that have changed between invocations, you can set the `scapegoatRunAlways` setting to false. You can then manually force a full inspection by invoking the `scapegoatClean` task, or by doing a full `clean`.
 
 #### Inspections list
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ task:
 [info] [scapegoat]: Written XML report [/home/sam/development/workspace/elastic4s/target/scala-2.11/scapegoat-report/scapegoat.xml]
 ```
 
-You should find the reports inside `target/scala-2.11/scapegoat-report`.
+You should find the reports inside `target/scala-2.11/scapegoat-report`. By default, the reports will be regenerated for all files on every invocation of the `scapegoat` task. If you'd prefer to only have reports generated for files that have changed between invocations, you can set the `scapegoatAlways` setting to false. You can then manually force a full inspection by invoking the `scapegoatForceClean` task, or by doing a full `clean`.
 
 #### Inspections list
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "sbt-scapegoat"
 
 organization := "com.sksamuel.scapegoat"
 
-version := "1.0.0"
+version := "1.0.1-SNAPSHOT"
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8")
 

--- a/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
@@ -14,12 +14,12 @@ object ScapegoatSbtPlugin extends AutoPlugin {
     val Scapegoat = config("scapegoat") extend Compile
 
     lazy val scapegoat = taskKey[Unit]("Run scapegoat quality checks")
+    lazy val scapegoatCleanTask = taskKey[Unit]("Conditionally clean the scapegoat output directories")
     lazy val scapegoatClean = taskKey[Unit]("Clean the scapegoat output directories")
-    lazy val scapegoatForceClean = taskKey[Unit]("Clean the scapegoat output directories")
     lazy val scapegoatVersion = settingKey[String]("The version of the scala plugin to use")
     lazy val scapegoatDisabledInspections = settingKey[Seq[String]]("Inspections that are disabled globally")
     lazy val scapegoatEnabledInspections = settingKey[Seq[String]]("Inspections that are explicitly enabled")
-    lazy val scapegoatAlways = settingKey[Boolean]("Force inspections to run even on files that haven't changed")
+    lazy val scapegoatRunAlways = settingKey[Boolean]("Force inspections to run even on files that haven't changed")
     lazy val scapegoatIgnoredFiles = settingKey[Seq[String]]("File patterns to ignore")
     lazy val scapegoatMaxErrors = settingKey[Int]("Maximum number of errors before the build will fail")
     lazy val scapegoatMaxWarnings = settingKey[Int]("Maximum number of warnings before the build will fail")
@@ -88,9 +88,9 @@ object ScapegoatSbtPlugin extends AutoPlugin {
     } ++ Seq(
       (compile in Scapegoat) <<= (compile in Scapegoat) dependsOn scapegoatClean,
       scapegoat := (compile in Scapegoat).value,
-      scapegoatClean := doScapegoatClean(scapegoatAlways.value, (classDirectory in Scapegoat).value, streams.value.log),
-      scapegoatForceClean := doScapegoatClean(true, (classDirectory in Scapegoat).value, streams.value.log),
-      scapegoatAlways   := true,
+      scapegoatCleanTask := doScapegoatClean(scapegoatRunAlways.value, (classDirectory in Scapegoat).value, streams.value.log),
+      scapegoatClean := doScapegoatClean(true, (classDirectory in Scapegoat).value, streams.value.log),
+      scapegoatRunAlways   := true,
       scapegoatVersion := "1.0.0",
       scapegoatConsoleOutput := true,
       scapegoatVerbose := true,

--- a/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
@@ -76,7 +76,6 @@ object ScapegoatSbtPlugin extends AutoPlugin {
       )
     } ++ Seq(
       scapegoat := {
-        clean.value
         (compile in Scapegoat).value
       },
       scapegoatVersion := "1.0.0",


### PR DESCRIPTION
Fixes #31

Instead of forcing a full clean, instead we now have a `scapegoatClean` task
that will remove _only_ the scapegoat-classes directory, which will force a
regeneration of reports for all source files. There is a setting to control
whether or not this happens on every invocation, `scapegoatAlways`, which
defaults to true.

Documentation is on the way...