### PR TITLE
Explicitly delegate managedClasspath so that provided deps. are added to classpath

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
@@ -43,6 +43,8 @@ object ScapegoatSbtPlugin extends AutoPlugin {
       Defaults.compileSettings ++
       Seq(
         sources := (sources in Compile).value,
+        managedClasspath := (managedClasspath in Compile).value,
+        unmanagedClasspath := (unmanagedClasspath in Compile).value,
         scalacOptions := {
           // find all deps for the compile scope
           val scapegoatDependencies = (update in Scapegoat).value matching configurationFilter(Compile.name)


### PR DESCRIPTION
This patch fixes #34, an issue where provided dependencies were not added to the compile classpath when running the `scapegoat` task. There's probably a more principled way to fix this, but this is the minimal fix that worked for me.