### PR TITLE
Provided scope fix

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
@@ -104,7 +104,7 @@ object ScapegoatSbtPlugin extends AutoPlugin {
       scapegoatCleanTask := doScapegoatClean((scapegoatRunAlways in ThisBuild).value, (classDirectory in Scapegoat).value, streams.value.log),
       scapegoatClean := doScapegoatClean(true, (classDirectory in Scapegoat).value, streams.value.log),
       // FIXME Cannot seem to make this a build setting (compile:crossTarget is an undefined setting)
-      scapegoatOutputPath := (crossTarget in Compile).value.getAbsolutePath + "/scapegoat-report",
-      libraryDependencies ++= Seq(GroupId %% ArtifactId % (scapegoatVersion in ThisBuild).value % Provided))
+      scapegoatOutputPath := (crossTarget in Provided).value.getAbsolutePath + "/scapegoat-report",
+      libraryDependencies += GroupId %% ArtifactId % (scapegoatVersion in ThisBuild).value % Provided)
   }
 }


### PR DESCRIPTION
It turned out, that PRs: #58 and #62 introduced a bug with a `scapegoat` task usage.
The possible error report looks like this:

```
sbt:scapegoat-not-working> scapegoat
[info] [scapegoat] Removing scapegoat class directory: /../scapegoat-not-working/target/scala-2.12/scapegoat-classes
[info] Updating ...
[info] Done updating.
[error] java.lang.Exception: Fatal: scalac-scapegoat-plugin not in libraryDependencies (Vector(/.../.sbt/boot/scala-2.12.4/lib/scala-library.jar))
[error] 	at com.sksamuel.scapegoat.sbt.ScapegoatSbtPlugin$.$anonfun$projectSettings$4(ScapegoatSbtPlugin.scala:67)
[error] 	at com.sksamuel.scapegoat.sbt.ScapegoatSbtPlugin$$$Lambda$3014/1243827743.apply(Unknown Source)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:44)
[error] 	at scala.Function1$$Lambda$594/1604020967.apply(Unknown Source)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:39)
[error] 	at sbt.internal.util.$tilde$greater$$Lambda$2296/757788974.apply(Unknown Source)
[error] 	at sbt.std.Transform$$anon$4.work(System.scala:66)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:262)
[error] 	at sbt.Execute$$Lambda$2313/591501007.apply(Unknown Source)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[error] 	at sbt.Execute.work(Execute.scala:271)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:262)
[error] 	at sbt.Execute$$Lambda$2304/1190799998.apply(Unknown Source)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:174)
[error] 	at sbt.ConcurrentRestrictions$$anon$4$$Lambda$2311/1614556654.apply(Unknown Source)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:36)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
[error] 	at java.lang.Thread.run(Thread.java:745)
[error] (Scapegoat / scalacOptions) java.lang.Exception: Fatal: scalac-scapegoat-plugin not in libraryDependencies (Vector(/.../.sbt/boot/scala-2.12.4/lib/scala-library.jar))
```

Fixes #63

@daron666 can you double check that it works for you?