### PR TITLE
enable cross-releasing for both sbt 0.13 and 1.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import sbtrelease.ReleaseStateTransformations._
+
 name := "sbt-scapegoat"
 
 organization := "com.sksamuel.scapegoat"
@@ -9,6 +11,8 @@ javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 scalaVersion := "2.12.6"
 
 sbtPlugin := true
+
+crossSbtVersions := Seq("0.13.17", "1.1.6")
 
 publishTo := {
     val isSnapshotValue = isSnapshot.value
@@ -24,8 +28,21 @@ publishArtifact in Test := false
 parallelExecution in Test := false
 
 sbtrelease.ReleasePlugin.autoImport.releasePublishArtifactsAction := PgpKeys.publishSigned.value
+sbtrelease.ReleasePlugin.autoImport.releaseCrossBuild := true
 
-sbtrelease.ReleasePlugin.autoImport.releaseCrossBuild := false
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  releaseStepCommandAndRemaining("^test"),
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  releaseStepCommandAndRemaining("^publish"),
+  setNextVersion,
+  commitNextVersion,
+  pushChanges
+)
 
 pgpSecretRing := file("/home/sam/Downloads/gpg.private")
 


### PR DESCRIPTION
This enables use of the sbt-scapegoat plugin in sbt 0.13 projects without having to do
`(scalaBinaryVersion in ThisBuild) := "2.12"` which causes lots of problems with projects doing cross-compiling.