### PR TITLE
Add the compiler plugin dependency to a custom Ivy configuration

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/sbt/ScapegoatSbtPlugin.scala
@@ -63,7 +63,7 @@ object ScapegoatSbtPlugin extends AutoPlugin {
           unmanagedClasspath := (unmanagedClasspath in Compile).value,
           scalacOptions := {
             // find all deps for the compile scope
-            val scapegoatDependencies = (update in Scapegoat).value matching configurationFilter(Provided.name)
+            val scapegoatDependencies = (update in Scapegoat).value matching configurationFilter("scapegoat")
             // ensure we have the scapegoat dependency on the classpath and if so add it as a scalac plugin
             scapegoatDependencies.find(_.getAbsolutePath.contains(ArtifactId)) match {
               case None => throw new Exception(s"Fatal: $ArtifactId not in libraryDependencies ($scapegoatDependencies)")
@@ -106,13 +106,14 @@ object ScapegoatSbtPlugin extends AutoPlugin {
             }
           })
     } ++ Seq(
+      ivyConfigurations += Configuration.of("Scapegoat", "scapegoat").hide,
       (compile in Scapegoat) := ((compile in Scapegoat) dependsOn scapegoatClean).value,
       scapegoat := (compile in Scapegoat).value,
       scapegoatCleanTask := doScapegoatClean((scapegoatRunAlways in ThisBuild).value, (classDirectory in Scapegoat).value, streams.value.log),
       scapegoatClean := doScapegoatClean(true, (classDirectory in Scapegoat).value, streams.value.log),
       // FIXME Cannot seem to make this a build setting (compile:crossTarget is an undefined setting)
       scapegoatOutputPath := (crossTarget in Compile).value.getAbsolutePath + "/scapegoat-report",
-      libraryDependencies ++= Seq(crossVersion(GroupId %% ArtifactId % (scapegoatVersion in ThisBuild).value % Provided)))
+      libraryDependencies += crossVersion(GroupId %% ArtifactId % (scapegoatVersion in ThisBuild).value % "scapegoat"))
   }
 
   private def crossVersion(mod: ModuleID) = {


### PR DESCRIPTION
Currently the `scalac-scapegoat-plugin_$scalaVersion` dependency is added to the built-in `provided` configuration.

That means the dependency leaks into the `pom.xml` of any project that uses sbt-scapegoat:

```
<dependency>
    <groupId>com.sksamuel.scapegoat</groupId>
    <artifactId>scalac-scapegoat-plugin_2.13.1</artifactId>
    <version>1.4.1</version>
    <scope>provided</scope>
</dependency>
```

This PR avoids that by creating a new private Ivy configuration called `scapegoat` and adding the dependency to that configuration.

It still leaks into the Ivy XML but not into the pom. Given that most people publish their libraries using Maven, I think that's a reasonable improvement.